### PR TITLE
feat: added Korean timezone

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,7 @@ export default {
   TIMEZONES: [
     { abbr: 'PDT', zone: 'America/Los_Angeles' },
     { abbr: 'AEST', zone: 'Australia/Brisbane' },
+    { abbr: 'KST', zone: 'Asia/Seoul' },
     { abbr: 'EEST', zone: 'Asia/Beirut' },
     { abbr: 'UTC', zone: 'Europe/London' },
     { abbr: 'UK', zone: 'Europe/London' },


### PR DESCRIPTION
Added Korean timezone. After adding all timezones, then chat screen will be full as @AllanRegush said. Seems bot doesn't have to show all time zones.